### PR TITLE
Remove deprecated --embedded flag

### DIFF
--- a/src/emsdk.js
+++ b/src/emsdk.js
@@ -33,4 +33,4 @@ function emsdk(args) {
 }
 
 const args = process.argv.slice(2);
-emsdk(['--embedded'].concat(args));
+emsdk(args);


### PR DESCRIPTION
The way that arguments are parsed by `emsdk.py` was [updated recently](https://github.com/emscripten-core/emsdk/commits/master/emsdk.py), and the `--embedded` flag has been removed by the maintainers. Now, adding the `--embedded` flag throws an error:

```
$ ~/perspective/node_modules/.bin/emsdk install 2.0.6
Unknown command '--embedded' given! Type 'emsdk help' to get a list of commands.
```

This PR removes `--embedded` for the emsdk commands to work - I've tested this locally and it continues to save Emscripten in the local path instead of `$HOME`, which is the expected behaviour.
